### PR TITLE
Added support for issuer URL's that end in /, such as auth0 is using.

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -110,11 +110,11 @@ func NewProvider(issuer *url.URL, config *ProviderConfig) (*Provider, error) {
 	if config.WellKnownURI != nil {
 		p.wellKnownURI = config.WellKnownURI
 	} else {
-		wellKnownURI, err := url.Parse(p.issuer + "/.well-known/openid-configuration")
+		relativeWellKnownURI, err := url.Parse("/.well-known/openid-configuration")
 		if err != nil {
 			return nil, err
 		}
-		p.wellKnownURI = wellKnownURI
+		p.wellKnownURI = issuer.ResolveReference(relativeWellKnownURI)
 	}
 	if config.Logger != nil {
 		p.logger = config.Logger


### PR DESCRIPTION
Currently, issuers that end in '/' fail with an error to retrieve the openid-configuration. In practice this means that issuers like [https://sample.auth0.com/.well-known/openid-configuration](https://sample.auth0.com/.well-known/openid-configuration) will not work. After this patch issuers ending in '/' work as expected.